### PR TITLE
Issue#119 amends to toolbox component positioning

### DIFF
--- a/src/scenes/Editor/components/Toolbox/ToolboxItems/Illustration.tsx
+++ b/src/scenes/Editor/components/Toolbox/ToolboxItems/Illustration.tsx
@@ -28,7 +28,7 @@ function Illustration() {
       >
         <Icons.FillColor size={24} color="#000000" />
       </Button>
-      <div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
         <Position />
         <Opacity />
         <Duplicate />

--- a/src/scenes/Editor/components/Toolbox/ToolboxItems/Image.tsx
+++ b/src/scenes/Editor/components/Toolbox/ToolboxItems/Image.tsx
@@ -28,7 +28,7 @@ function Image() {
       >
         <Icons.FillColor size={24} color="#000000" />
       </Button>
-      <div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
         <Position />
         <Opacity />
         <Duplicate />

--- a/src/scenes/Editor/components/Toolbox/ToolboxItems/Path.tsx
+++ b/src/scenes/Editor/components/Toolbox/ToolboxItems/Path.tsx
@@ -28,7 +28,7 @@ function Path() {
       >
         <Icons.FillColor size={24} color="#000000" />
       </Button>
-      <div style={{ display: 'flex' }}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
         <Position />
         <Opacity />
         <Duplicate />


### PR DESCRIPTION
Essentially set the div to flex and aligning items in the centre. This was set on the Text component but not the rest which was causing the differences as you selected different types of items